### PR TITLE
Remove unused models

### DIFF
--- a/lib/models.json
+++ b/lib/models.json
@@ -43,13 +43,6 @@
       "multiModal": true
     },
     {
-      "id": "gpt-4.5-preview",
-      "provider": "OpenAI",
-      "providerId": "openai",
-      "name": "GPT-4.5 (preview)",
-      "multiModal": true
-    },
-    {
       "id": "gpt-4o",
       "provider": "OpenAI",
       "providerId": "openai",
@@ -61,27 +54,6 @@
       "provider": "OpenAI",
       "providerId": "openai",
       "name": "GPT-4o mini",
-      "multiModal": true
-    },
-    {
-      "id": "o1",
-      "provider": "OpenAI",
-      "providerId": "openai",
-      "name": "o1",
-      "multiModal": true
-    },
-    {
-      "id": "o1-mini",
-      "provider": "OpenAI",
-      "providerId": "openai",
-      "name": "o1-mini",
-      "multiModal": false
-    },
-    {
-      "id": "gpt-4-turbo",
-      "provider": "OpenAI",
-      "providerId": "openai",
-      "name": "GPT-4 Turbo",
       "multiModal": true
     },
     {
@@ -120,48 +92,6 @@
       "multiModal": true
     },
     {
-      "id": "gemini-2.5-flash-preview-05-20",
-      "provider": "Google Vertex AI",
-      "providerId": "vertex",
-      "name": "Gemini 2.5 Flash Preview 05-20",
-      "multiModal": true
-    },
-    {
-      "id": "gemini-2.5-pro-preview-05-06",
-      "provider": "Google Vertex AI",
-      "providerId": "vertex",
-      "name": "Gemini 2.5 Pro Preview 05-06",
-      "multiModal": true
-    },
-    {
-      "id": "gemini-2.0-flash-001",
-      "provider": "Google Vertex AI",
-      "providerId": "vertex",
-      "name": "Gemini 2.0 Flash",
-      "multiModal": true
-    },
-    {
-      "id": "gemini-2.0-flash-lite-001",
-      "provider": "Google Vertex AI",
-      "providerId": "vertex",
-      "name": "Gemini 2.0 Flash Lite",
-      "multiModal": true
-    },
-    {
-      "id": "gemini-1.5-pro-002",
-      "provider": "Google Vertex AI",
-      "providerId": "vertex",
-      "name": "Gemini 1.5 Pro",
-      "multiModal": true
-    },
-    {
-      "id": "gemini-1.5-flash-002",
-      "provider": "Google Vertex AI",
-      "providerId": "vertex",
-      "name": "Gemini 1.5 Flash",
-      "multiModal": true
-    },
-    {
       "id": "models/gemini-2.5-flash-preview-05-20",
       "provider": "Google Generative AI",
       "providerId": "google",
@@ -187,20 +117,6 @@
       "provider": "Google Generative AI",
       "providerId": "google",
       "name": "Gemini 2.0 Flash Lite",
-      "multiModal": true
-    },
-    {
-      "id": "models/gemini-1.5-pro",
-      "provider": "Google Generative AI",
-      "providerId": "google",
-      "name": "Gemini 1.5 Pro",
-      "multiModal": true
-    },
-    {
-      "id": "models/gemini-1.5-flash",
-      "provider": "Google Generative AI",
-      "providerId": "google",
-      "name": "Gemini 1.5 Flash",
       "multiModal": true
     },
     {
@@ -236,13 +152,6 @@
       "provider": "Mistral",
       "providerId": "mistral",
       "name": "Mistral Nemo",
-      "multiModal": false
-    },
-    {
-      "id": "llama-3.3-70b-versatile",
-      "provider": "Groq",
-      "providerId": "groq",
-      "name": "Llama 3.3 70B (Preview)",
       "multiModal": false
     },
     {
@@ -292,13 +201,6 @@
       "provider": "Fireworks",
       "providerId": "fireworks",
       "name": "DeepSeek R1"
-    },
-    {
-      "id": "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
-      "provider": "Together AI",
-      "providerId": "togetherai",
-      "name": "Llama 3.1 70B",
-      "multiModal": false
     },
     {
       "id": "grok-beta",


### PR DESCRIPTION
## Summary
- remove OpenAI models: GPT-4.5 preview, o1, o1-mini and GPT-4 Turbo
- remove Google Vertex AI provider and models
- remove Gemini 1.5 Pro and 1.5 Flash from Google Generative AI
- drop Groq, Together AI, xAI Grok and DeepSeek V3
- restore Grok Beta model for xAI
- restore DeepSeek V3 model

## Testing
- `npm run lint` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_6842fcef5fac832aa65b35e1fa25c675